### PR TITLE
Added mechanism to cache applications

### DIFF
--- a/mrblib/context.rb
+++ b/mrblib/context.rb
@@ -27,6 +27,7 @@ class Context
   end
 
   def self.ruby(app, platform, json)
+    ContextLog.info "context self.ruby #{app}-#{json}"
     $LOAD_PATH = ["./#{app}"]
 
     if Object.const_defined? :Platform
@@ -46,6 +47,7 @@ class Context
   end
 
   def self.setup(app, platform)
+    ContextLog.info "context self.setup #{app}-#{platform}"
     # Library responsable for common code and API syntax for the user
     if File.exist?("./#{app}/da_funk.mrb")
       require "da_funk.mrb"
@@ -67,6 +69,28 @@ class Context
     end
     DaFunk::PaymentChannel.client = Context::CommunicationChannel
     Device::Runtime.system_reload
+  end
+
+  def self.load_apps(app, platform)
+    ContextLog.info "context self.load_apps #{app}-#{platform}"
+    $LOAD_PATH = ["./#{app}"]
+
+    if Object.const_defined? :Platform
+      Platform.boot if Platform.respond_to?(:boot)
+    end
+    self.setup(app, platform)
+  end
+
+  def self.execute_app(app, json = nil)
+    ContextLog.info "context self.execute_app #{app}-#{json}"
+    $LOAD_PATH = ["./#{app}"]
+    Device::System.klass = app if require "main.mrb"
+
+    if json.nil? || json.empty?
+      Main.call
+    else
+      Main.call(json)
+    end
   end
 
   def self.teardown

--- a/mrblib/thread_scheduler.rb
+++ b/mrblib/thread_scheduler.rb
@@ -29,7 +29,8 @@ class ThreadScheduler
   def self.spawn_status_bar
     if DaFunk::Helper::StatusBar.valid?
       _start(THREAD_STATUS_BAR)
-      str = "Context.start('main', '#{Device.adapter}', '{\"initialize\":\"status_bar\"}')"
+      str = "Context.start('main', '#{Device.adapter}');"
+      str << "Context.execute('main', '#{Device.adapter}', '{\"initialize\":\"status_bar\"}')"
       self.status_bar = Thread.new do
         mrb_eval(str)
         _stop(THREAD_STATUS_BAR)
@@ -47,7 +48,8 @@ class ThreadScheduler
 
   def self.spawn_communication
     _start(THREAD_COMMUNICATION)
-    str = "Context.start('main', '#{Device.adapter}', '{\"initialize\":\"communication\"}')"
+    str = "Context.start('main', '#{Device.adapter}'); "
+    str << "Context.execute('main', '#{Device.adapter}', '{\"initialize\":\"communication\"}')"
     self.communication = Thread.new do
       mrb_eval(str)
       _stop(THREAD_COMMUNICATION)

--- a/mrblib/thread_scheduler.rb
+++ b/mrblib/thread_scheduler.rb
@@ -32,7 +32,7 @@ class ThreadScheduler
       str = "Context.start('main', '#{Device.adapter}');"
       str << "Context.execute('main', '#{Device.adapter}', '{\"initialize\":\"status_bar\"}')"
       self.status_bar = Thread.new do
-        mrb_eval(str)
+        mrb_eval(str, 'thread_status_bar')
         _stop(THREAD_STATUS_BAR)
       end
     end
@@ -51,7 +51,7 @@ class ThreadScheduler
     str = "Context.start('main', '#{Device.adapter}'); "
     str << "Context.execute('main', '#{Device.adapter}', '{\"initialize\":\"communication\"}')"
     self.communication = Thread.new do
-      mrb_eval(str)
+      mrb_eval(str, 'thread_communication')
       _stop(THREAD_COMMUNICATION)
     end
   end


### PR DESCRIPTION
Now we split the Context.start method in two phases.
First, Context.start is responsible only to load in an instance list all ruby applications from params.dat file. Second, the method Context.execute only execute one of those applications.