### PR TITLE
Added exception for application that doesn't use parameters

### DIFF
--- a/mrblib/context.rb
+++ b/mrblib/context.rb
@@ -48,10 +48,10 @@ class Context
       #Device::System.klass = app
       # Main should have implement method call
       #  method call was need to avoid memory leak on irep table
-      if json.nil? || json.empty?
-        Main.call
-      else
+      begin
         Main.call(json)
+      rescue ArgumentError
+        Main.call
       end
     end
   end


### PR DESCRIPTION
In order to prevent argument error on ruby applications that doesn't handle parameters, we've to include a rescue for ArgumentError exception.